### PR TITLE
Add button to clear dashboard cache

### DIFF
--- a/app/Http/Controllers/Admin/AdminController.php
+++ b/app/Http/Controllers/Admin/AdminController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Models\User;
 use Spatie\Permission\Models\Role;
 use Spatie\Permission\Models\Permission;
+use Illuminate\Support\Facades\Artisan;
 
 class AdminController extends Controller
 {
@@ -19,5 +20,22 @@ class AdminController extends Controller
         ];
 
         return view('admin.dashboard', compact('stats'));
+    }
+
+    public function clearCaches()
+    {
+        try {
+            Artisan::call('optimize:clear');
+            Artisan::call('cache:clear');
+            Artisan::call('config:clear');
+            Artisan::call('route:clear');
+            Artisan::call('view:clear');
+            // Reset Spatie permission cache if available
+            Artisan::call('permission:cache-reset');
+
+            return redirect()->back()->with('success', 'All caches cleared successfully.');
+        } catch (\Throwable $e) {
+            return redirect()->back()->with('error', 'Failed to clear caches: ' . $e->getMessage());
+        }
     }
 }

--- a/resources/views/admin/dashboard.blade.php
+++ b/resources/views/admin/dashboard.blade.php
@@ -192,6 +192,23 @@
                                 </div>
                             </a>
                             @endcan
+
+                            <form method="POST" action="{{ route('admin.clear-caches') }}" onsubmit="return confirm('Clear all caches? This may take a few seconds.');">
+                                @csrf
+                                <button type="submit" class="block w-full p-4 bg-gradient-to-r from-red-500 to-red-600 rounded-xl text-white hover:from-red-600 hover:to-red-700 transition-all duration-300 transform hover:scale-105">
+                                    <div class="flex items-center">
+                                        <div class="w-10 h-10 bg-white/20 rounded-lg flex items-center justify-center mr-4">
+                                            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v6h6M20 20v-6h-6M5 19a9 9 0 0014-7 9 9 0 00-9-9 9 9 0 00-5 1.7"></path>
+                                            </svg>
+                                        </div>
+                                        <div>
+                                            <h3 class="font-semibold">Clear All Caches</h3>
+                                            <p class="text-red-100 text-sm">Flush app, config, route and view caches</p>
+                                        </div>
+                                    </div>
+                                </button>
+                            </form>
                         </div>
                     </div>
                 </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -27,6 +27,7 @@ Route::middleware('auth')->group(function () {
 Route::middleware(['auth', 'permission:access admin panel'])->prefix('admin')->name('admin.')->group(function () {
     // Dashboard
     Route::get('/', [AdminController::class, 'dashboard'])->name('dashboard');
+    Route::post('/clear-caches', [AdminController::class, 'clearCaches'])->name('clear-caches');
     
     // User management
     Route::middleware('permission:view users')->group(function () {


### PR DESCRIPTION
Add a "Clear All Caches" button to the admin dashboard to allow administrators to flush various application caches.

---
<a href="https://cursor.com/background-agent?bcId=bc-5c4709b4-fd6a-4ffc-8354-959cf70e6dad">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5c4709b4-fd6a-4ffc-8354-959cf70e6dad">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

