### PR TITLE
Fix futures analysis timeframes display

### DIFF
--- a/app/Http/Controllers/FuturesTradingBotController.php
+++ b/app/Http/Controllers/FuturesTradingBotController.php
@@ -35,7 +35,7 @@ class FuturesTradingBotController extends Controller
             ->where('exchange', '!=', 'coinbase') // Most exchanges support futures
             ->get();
 
-        $timeframes = ['15m', '30m', '1h'];
+        $timeframes = ['1m', '5m', '15m'];
         $leverages = [1, 2, 3, 5, 10, 20, 50, 100];
         $marginTypes = ['isolated', 'cross'];
         $positionSides = ['long', 'short', 'both'];
@@ -52,7 +52,7 @@ class FuturesTradingBotController extends Controller
             'risk_percentage' => 'required|numeric|min:0.1|max:10',
             'max_position_size' => 'required|numeric|min:0.001',
             'timeframes' => 'required|array|min:1',
-            'timeframes.*' => 'in:15m,30m,1h',
+            'timeframes.*' => 'in:1m,5m,15m',
             'leverage' => 'required|integer|min:1|max:100',
             'margin_type' => 'required|in:isolated,cross',
             'position_side' => 'required|in:long,short,both',
@@ -140,7 +140,7 @@ class FuturesTradingBotController extends Controller
             ->where('is_active', true)
             ->get();
 
-        $timeframes = ['15m', '30m', '1h'];
+        $timeframes = ['1m', '5m', '15m'];
         $leverages = [1, 2, 3, 5, 10, 20, 50, 100];
         $marginTypes = ['isolated', 'cross'];
         $positionSides = ['long', 'short', 'both'];
@@ -162,7 +162,7 @@ class FuturesTradingBotController extends Controller
             'risk_percentage' => 'required|numeric|min:0.1|max:10',
             'max_position_size' => 'required|numeric|min:0.001',
             'timeframes' => 'required|array|min:1',
-            'timeframes.*' => 'in:15m,30m,1h',
+            'timeframes.*' => 'in:1m,5m,15m',
             'leverage' => 'required|integer|min:1|max:100',
             'margin_type' => 'required|in:isolated,cross',
             'position_side' => 'required|in:long,short,both',

--- a/resources/views/futures-bots/create.blade.php
+++ b/resources/views/futures-bots/create.blade.php
@@ -173,7 +173,7 @@
                         @foreach($timeframes as $timeframe)
                             <label class="flex items-center">
                                 <input type="checkbox" name="timeframes[]" value="{{ $timeframe }}" 
-                                    {{ in_array($timeframe, old('timeframes', ['15m', '30m', '1h'])) ? 'checked' : '' }}
+                                    {{ in_array($timeframe, old('timeframes', ['1m', '5m', '15m'])) ? 'checked' : '' }}
                                     class="rounded border-gray-300 text-blue-600 shadow-sm focus:border-blue-300 focus:ring focus:ring-blue-200 focus:ring-opacity-50">
                                 <span class="ml-2 text-sm font-medium text-gray-700">{{ $timeframe }}</span>
                             </label>


### PR DESCRIPTION
Update futures analysis timeframes to 1m, 5m, 15m as per user request.

---
<a href="https://cursor.com/background-agent?bcId=bc-fd7bbc0c-fd8f-40f5-b6d4-e5e70f7f8674">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fd7bbc0c-fd8f-40f5-b6d4-e5e70f7f8674">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

